### PR TITLE
at 3-rd level categories (and deeper) will not be selected as active

### DIFF
--- a/frontend/controllers/CatalogController.php
+++ b/frontend/controllers/CatalogController.php
@@ -91,7 +91,7 @@ class CatalogController extends \yii\web\Controller
                 ];
                 break;
             } elseif (!empty($menuItems[$id]['items'])) {
-                $this->placeCategory($category, $menuItems[$id]['items']);
+                $this->placeCategory($category, $menuItems[$id]['items'], $activeId);
             }
         }
     }


### PR DESCRIPTION
at 3-rd level categories (and deeper) will not be selected as "active" if we will not pass $activeId to recursion
