### PR TITLE
if goods must appear at third level of categories (and deeper)

### DIFF
--- a/frontend/controllers/CatalogController.php
+++ b/frontend/controllers/CatalogController.php
@@ -107,12 +107,11 @@ class CatalogController extends \yii\web\Controller
     private function getCategoryIds($categories, $categoryId, &$categoryIds = [])
     {
         foreach ($categories as $category) {
-            if ($category->id == $categoryId || $category->parent_id == $categoryId) {
+            if ($category->id == $categoryId) {
                 $categoryIds[] = $category->id;
             }
-            if (isset($categories[$categoryId]['items'])) {
-                foreach ($categories[$categoryId]['items'] as $subCategoryId => $subCategory)
-                $this->getCategoryIds($categories, $subCategoryId, $categoryIds);
+            elseif ($category->parent_id == $categoryId){
+                $this->getCategoryIds($categories, $category->id, $categoryIds);
             }
         }
         return $categoryIds;


### PR DESCRIPTION
In case if goods must appear at third level of categories (and deeper)
it will be impossible to see goods (if they are exist).
For example, categories like this (uppercase) and goods like this (lowercase)
- COMPUTERS
- \- APPLE
- \- - iPADS       (iPad1,iPad2,iPad3...)
- \- - iPHONES     (iPhone 16Gb, iPhone 32Gb, iPhone 64Gb)
- \- - MACBOOK PRO (MacBook 2013, MacBook 2014)
  - - - 
- \- IBM
- \- - SOFTWARE      (Software 1, Software 2)
- \- - HARDWARE      (IBM Server 1,IBM Server 2)
- \- ASUS    [good, that will be shown 1, good, that will be shown 2]
- - ACER    [good, that will be shown 3, good, that will be shown 4]
  
  When you are at frontend, at "Catalog/list" route, if you click by "COMPUTERS" category link, 
  All this goods (in parentheses) will not appear at the list by right side.
  because this part of code (function getCategoryIds) will not (and never) executed:
  
  if (isset($categories[$categoryId]['items'])) {`
            foreach ($categories[$categoryId]['items'] as $subCategoryId => $subCategory)
            $this->getCategoryIds($categories, $subCategoryId, $categoryIds);
  }
  
  But, goods of first and second level of categories (in square brackets), 
  will be shown, because of this part of code:
  
  ```
   if ($category->id == $categoryId || $category->parent_id == $categoryId) {
        $categoryIds[] = $category->id;
    }
  ```
  
  The problem is: Recursion is not executed.
  What is "items"?, its look like not defined (actually, values by dimension [items])
