### PR TITLE
In case if child category has less id value than parent category, chi…

### DIFF
--- a/frontend/controllers/CatalogController.php
+++ b/frontend/controllers/CatalogController.php
@@ -54,47 +54,25 @@ class CatalogController extends \yii\web\Controller
     /**
      * @param Category[] $categories
      * @param int $activeId
+     * @param int $parent
      * @return array
      */
-    private function getMenuItems($categories, $activeId = null)
+    private function getMenuItems($categories, $activeId = null, $parent = null)
     {
         $menuItems = [];
         foreach ($categories as $category) {
-            if ($category->parent_id === null) {
+            if ($category->parent_id === $parent) {
                 $menuItems[$category->id] = [
                     'active' => $activeId === $category->id,
                     'label' => $category->title,
                     'url' => ['catalog/list', 'id' => $category->id],
+                    'items' => $this->getMenuItems($categories, $activeId, $category->id),
                 ];
-            } else {
-                $this->placeCategory($category, $menuItems, $activeId);
             }
         }
         return $menuItems;
     }
 
-    /**
-     * Places category menu item into menu tree
-     *
-     * @param Category $category
-     * @param $menuItems
-     * @param int $activeId
-     */
-    private function placeCategory($category, &$menuItems, $activeId = null)
-    {
-        foreach ($menuItems as $id => $navLink) {
-            if ($category->parent_id === $id) {
-                $menuItems[$id]['items'][$category->id] = [
-                    'active' => $activeId === $category->id,
-                    'label' => $category->title,
-                    'url' => ['catalog/list', 'id' => $category->id],
-                ];
-                break;
-            } elseif (!empty($menuItems[$id]['items'])) {
-                $this->placeCategory($category, $menuItems[$id]['items'], $activeId);
-            }
-        }
-    }
 
     /**
      * Returns IDs of category and all its sub-categories


### PR DESCRIPTION
…ld category will not appear in menu structure.

For example 
Id   Title  Parent id
1   Cars    0
2   Mercedes    1

will shown correct in menu structure:
"Cars"
_"Mercedes"

But this variant: 
Id    Title Parent id
1   Mercedes    2
2   Cars    0
in menu structure will shown only:
"Cars"

Its happens because functions getMenuItems (and placeCategory) depend of category's order indexed by id.
If child category processing before parent-category, all child categories will not be shown.
But in real life child-category can have less id value than parent-category id because 
actually, i can define "parent-child" relationships anytime then i want (order of inputting data here is not to be important). 

The soltion:
better to use id-order-independent recursive function (actually this is vkabachenko's code)
